### PR TITLE
Correct RCTBridgeModule import priority to allow Expo core to be installed

### DIFF
--- a/ios/RNEmarsysGeofenceWrapper.h
+++ b/ios/RNEmarsysGeofenceWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNEmarsysGeofenceWrapper : NSObject <RCTBridgeModule>

--- a/ios/RNEmarsysInAppWrapper.h
+++ b/ios/RNEmarsysInAppWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNEmarsysInAppWrapper : NSObject <RCTBridgeModule>

--- a/ios/RNEmarsysInboxWrapper.h
+++ b/ios/RNEmarsysInboxWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNEmarsysInboxWrapper : NSObject <RCTBridgeModule>

--- a/ios/RNEmarsysPredictWrapper.h
+++ b/ios/RNEmarsysPredictWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNEmarsysPredictWrapper : NSObject <RCTBridgeModule>

--- a/ios/RNEmarsysPushWrapper.h
+++ b/ios/RNEmarsysPushWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNEmarsysPushWrapper : NSObject <RCTBridgeModule>

--- a/ios/RNEmarsysWrapper.h
+++ b/ios/RNEmarsysWrapper.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 #import <React/RCTEventEmitter.h>
 


### PR DESCRIPTION
In our app, we needed to [install Expo core](https://docs.expo.dev/bare/installing-expo-modules/) and we ran into iOS build issues related to the import of `RCTBridgeModule.h` in this Emarsys Wrapper.

To resolve this issue we have adjusted your wrapper to first try to import `<React/RCTBridgeModule.h>` before falling back to `"RCTBridgeModule.h"` (which allows backwards compatibility).

```
#if __has_include(<React/RCTBridgeModule.h>)
#import <React/RCTBridgeModule.h>
#else
#import "RCTBridgeModule.h"
#endif
```
instead of
```
#if __has_include("RCTBridgeModule.h")
#import "RCTBridgeModule.h"
#else
#import <React/RCTBridgeModule.h>
#endif
```

Note: To get this fix to be applied, we also needed to get CocoaPods to install the pod files from the local, patched, files, rather than the remote git URL specified in the podspec. To do this we added the following to our Podfile
`pod 'RNEmarsysWrapper', :path => '../node_modules/react-native-emarsys-wrapper/RNEmarsysWrapper.podspec'`
If you want to test out its PR branch in an example project, then you may also need to temporarily adjust your Podfile in the same way, so that CocoaPods use the local files.

Also, depending on what version of React Native you need to be backwards compatible to, you may just be able to use `#import <React/RCTBridgeModule.h>` by itself. The imports were changed in [React Native 0.40.0](https://github.com/facebook/react-native/releases/tag/v0.40.0), which was released in December 2016.

It would be great if you could merge this PR, or adjust/update the imports, and it would save us (and potential future customers) from having to manually patch it or fork it etc.