### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.14.0",
     "description": "React Native wrapper for Emarsys SDK",
     "main": "index.js",
+    "type": "module",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
We were trying to use the `react-native-emarsys-sdk` in a jest test environment. Jest does not recognize the sdk as a module, thus refusing to import it as a module. Adding the declaration in the `package.json` fixes the issue.

This is why we are asking you to merge this. :)